### PR TITLE
Add WC Product CSV Exporter limit filter

### DIFF
--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -50,6 +50,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 */
 	public function __construct() {
 		parent::__construct();
+		$this->set_limit(apply_filters( "woocommerce_product_export_{$this->export_type}_default_limit", $this->limit));
 		$this->set_product_types_to_export( array_merge( array_keys( wc_get_product_types() ), array( 'variation' ) ) );
 	}
 


### PR DESCRIPTION
with tons of products is nice to have an way to change the limit for the exporter (now is set to 50)


```php
function wc_exporter_set_limit($limit) {
  return 1000;
}
add_filter( 'woocommerce_product_export_product_default_limit', 'wc_exporter_set_limit');
```
